### PR TITLE
dicomsr conversion fixed to check if the aim with same name or beginn…

### DIFF
--- a/src/main/java/edu/stanford/epad/epadws/aim/AIMQueries.java
+++ b/src/main/java/edu/stanford/epad/epadws/aim/AIMQueries.java
@@ -392,6 +392,23 @@ public class AIMQueries
 			if (aims != null) {
 				resultAims.addAll(aims);
 			}
+		} else if (aimSearchType == AIMSearchType.SEG_INSTANCE_UID) { //seg instance uid for finding segmentation dsos
+			String dsoInstanceUID = value;
+			try {
+				List<edu.stanford.hakan.aim4api.base.ImageAnnotationCollection> iacs = edu.stanford.hakan.aim4api.usage.AnnotationGetter
+						.getImageAnnotationCollectionByDsoInstanceUIDEqual(eXistServerUrl, aim4Namespace,
+								collection4Name, eXistUsername, eXistPassword, dsoInstanceUID);
+				if (aims == null)
+					aims = new ArrayList<ImageAnnotation>();
+				for (int i = 0; i < iacs.size(); i++)
+					aims.add(new ImageAnnotation(iacs.get(i)));
+			} catch (edu.stanford.hakan.aim4api.base.AimException e) {
+				log.warning("Exception in AnnotationGetter.getImageAnnotationsFromServerByDsoInstanceUIDEqual "
+						+ dsoInstanceUID, e);
+			}
+			if (aims != null) {
+				resultAims.addAll(aims);
+			}
 		} else if (aimSearchType == AIMSearchType.ANNOTATION_UID) {
 			String annotationUID = value;
 			if (value.equals("all")) {

--- a/src/main/java/edu/stanford/epad/epadws/aim/AIMSearchType.java
+++ b/src/main/java/edu/stanford/epad/epadws/aim/AIMSearchType.java
@@ -108,7 +108,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public enum AIMSearchType {
-	PATIENT_ID("patientId"), SERIES_UID("seriesUID"), PERSON_NAME("personName"), ANNOTATION_UID("annotationUID"), TEMPLATE_CODE("templateCode"), AIM_QUERY("aimQL"), JSON_QUERY("jsonQuery");
+	PATIENT_ID("patientId"), SERIES_UID("seriesUID"), PERSON_NAME("personName"), ANNOTATION_UID("annotationUID"), TEMPLATE_CODE("templateCode"), AIM_QUERY("aimQL"), JSON_QUERY("jsonQuery"), SEG_INSTANCE_UID("segInstanceUID");
 
 	private String name;
 

--- a/src/main/java/edu/stanford/epad/epadws/aim/AIMUtil.java
+++ b/src/main/java/edu/stanford/epad/epadws/aim/AIMUtil.java
@@ -925,13 +925,15 @@ public class AIMUtil
 										if (!e.aimID.equals(eaim.aimID) && e.dsoSeriesUID != null && e.dsoSeriesUID.equals(dsoSeriesUID))
 										{
 											ImageReference imageReference = new ImageReference(projectID, e.subjectID, e.studyUID, e.seriesUID, e.imageUID);												
-											if (e.isDicomSR==false && eaim.isDicomSR==false)// if none of them are dicomsr
+											if ((eaim.name.equals(e.name) ||  eaim.name.equals(e.name.replace("ePAD DSO-", ""))||(e.isDicomSR==false && eaim.isDicomSR==false))){// if none of them are dicomsr
 												epadDatabaseOperations.deleteAIM("admin", e.aimID);
+												log.info("Deleting aim with name:" + e.name + " and aimID:" + eaim.aimID);
+											}
 											log.info("Updating dsoSeriesUID in aim database:" + e.dsoSeriesUID + " aimID:" + eaim.aimID);
 											epadDatabaseOperations.addDSOAIM(username, imageReference, e.dsoSeriesUID, eaim.aimID);												
 											if (eaim.dsoFrameNo == 0)
 												epadDatabaseOperations.updateAIMDSOFrameNo(eaim.aimID, e.dsoFrameNo);												
-											break;
+//											break;
 										}
 									}
 								}								

--- a/src/main/java/edu/stanford/epad/epadws/queries/DefaultEpadOperations.java
+++ b/src/main/java/edu/stanford/epad/epadws/queries/DefaultEpadOperations.java
@@ -1908,7 +1908,7 @@ public class DefaultEpadOperations implements EpadOperations
 				Aim2DicomSRConverter converter=new Aim2DicomSRConverter();
 				String xml=converter.DicomSR2Aim(uploadedFile.getAbsolutePath(), projectID);
 				if (xml==null) {
-					log.info("Could not convert to dicom sr");
+					log.info("Could not convert from dicom sr");
 				}else {
 					String tmpAimName="/tmp/tmpAim"+System.currentTimeMillis()+".xml";
 					File tmpAim=new File(tmpAimName);

--- a/src/main/java/edu/stanford/epad/epadws/service/UserProjectService.java
+++ b/src/main/java/edu/stanford/epad/epadws/service/UserProjectService.java
@@ -410,7 +410,7 @@ public class UserProjectService {
 							
 							String xml=converter.DicomSR2Aim(dicomFile.getAbsolutePath(), projectID);
 							if (xml==null) {
-								log.info("Could not convert to dicom sr");
+								log.info("Could not convert from dicom sr");
 							}else {
 								String tmpAimName="/tmp/tmpAim"+System.currentTimeMillis()+".xml";
 								File tmpAim=new File(tmpAimName);
@@ -502,6 +502,7 @@ public class UserProjectService {
 			log.warning("Dicom object couldn't be retrieved!");
 			return false;
 		}
+		String sopInstanceUID = dicomObject.getString(Tag.SOPInstanceUID);
 		String dicomPatientName = dicomObject.getString(Tag.PatientName);
 		String dicomPatientID = dicomObject.getString(Tag.PatientID);
 		String studyUID = dicomObject.getString(Tag.StudyInstanceUID);
@@ -570,7 +571,9 @@ public class UserProjectService {
 					//					if (ias.size() == 0 || aims.size() == 0) 
 					//						AIMUtil.generateAIMFileForDSO(dicomFile, username, projectID);
 					List<EPADAIM> aims = databaseOperations.getAIMsByDSOSeries(null, dicomPatientID, seriesUID);
-					List<ImageAnnotation> ias = AIMQueries.getAIMImageAnnotations(AIMSearchType.SERIES_UID, seriesUID, username, 1, 50);
+					log.info("getting annotations for dso w/uid "+sopInstanceUID);
+					List<ImageAnnotation> ias = AIMQueries.getAIMImageAnnotations(AIMSearchType.SEG_INSTANCE_UID, sopInstanceUID, username, 1, 50);
+					log.info("Found aims:"+ias.size());
 					boolean generateAim = false;
 					if (aims.size() == 1 && aims.get(0).projectID.equals(EPADConfig.xnatUploadProjectID) && !projectID.equals(EPADConfig.xnatUploadProjectID))
 						generateAim = true;


### PR DESCRIPTION
…ing w/ePad DSO and same name exist. stop converting if so. multiple aims for same dso deletes if the name is same. exist dso aim search fixed(was still trying to get from imageseries).new aim search type added (segmentation instance uid)